### PR TITLE
Added test

### DIFF
--- a/contracts/savings-app/tests/edge_cases.rs
+++ b/contracts/savings-app/tests/edge_cases.rs
@@ -1,0 +1,49 @@
+mod interface;
+use interface::*;
+
+use app::msg::{AppQueryMsgFns, AssetsBalanceResponse};
+use cosmwasm_std::{coin, coins, Decimal, Uint128};
+use cw_orch::{anyhow, prelude::*};
+
+use crate::interface::setup_test_tube;
+#[test]
+fn deposit_twice() -> anyhow::Result<()> {
+    let (_, savings_app) = setup_test_tube(false)?;
+
+    let chain = savings_app.get_chain().clone();
+
+    let deposit_amount = 5_000;
+    let max_fee = Uint128::new(deposit_amount).mul_floor(Decimal::percent(2));
+    // Create position
+    create_position(
+        &savings_app,
+        coins(deposit_amount, factory_denom(&chain, USDC)),
+        coin(1_000_000, factory_denom(&chain, USDC)),
+        coin(1_000_000, factory_denom(&chain, USDT)),
+    )?;
+    // Check almost everything landed
+    let balance: AssetsBalanceResponse = savings_app.balance()?;
+    let first_sum = balance
+        .balances
+        .iter()
+        .fold(Uint128::zero(), |acc, e| acc + e.amount);
+    assert!(first_sum.u128() > deposit_amount - max_fee.u128());
+
+    // Create a position once again
+    create_position(
+        &savings_app,
+        coins(deposit_amount, factory_denom(&chain, USDC)),
+        coin(1_000_000, factory_denom(&chain, USDC)),
+        coin(1_000_000, factory_denom(&chain, USDT)),
+    )?;
+
+    // Check almost everything landed
+    let balance: AssetsBalanceResponse = savings_app.balance()?;
+    let second_sum = balance
+        .balances
+        .iter()
+        .fold(Uint128::zero(), |acc, e| acc + e.amount);
+    assert!((second_sum - first_sum).u128() > deposit_amount - max_fee.u128());
+
+    Ok(())
+}

--- a/contracts/savings-app/tests/edge_cases.rs
+++ b/contracts/savings-app/tests/edge_cases.rs
@@ -7,13 +7,13 @@ use cw_orch::{anyhow, prelude::*};
 
 use crate::interface::setup_test_tube;
 #[test]
-fn deposit_twice() -> anyhow::Result<()> {
+fn create_multiple_positions_with_0funds() -> anyhow::Result<()> {
     let (_, savings_app) = setup_test_tube(false)?;
 
     let chain = savings_app.get_chain().clone();
 
     let deposit_amount = 5_000;
-    let max_fee = Uint128::new(deposit_amount).mul_floor(Decimal::percent(2));
+    let max_fee = Uint128::new(deposit_amount).mul_floor(Decimal::percent(1));
     // Create position
     create_position(
         &savings_app,
@@ -32,7 +32,7 @@ fn deposit_twice() -> anyhow::Result<()> {
     // Create a position once again
     create_position(
         &savings_app,
-        coins(deposit_amount, factory_denom(&chain, USDC)),
+        vec![],
         coin(1_000_000, factory_denom(&chain, USDC)),
         coin(1_000_000, factory_denom(&chain, USDT)),
     )?;
@@ -43,7 +43,7 @@ fn deposit_twice() -> anyhow::Result<()> {
         .balances
         .iter()
         .fold(Uint128::zero(), |acc, e| acc + e.amount);
-    assert!((second_sum - first_sum).u128() > deposit_amount - max_fee.u128());
+    assert!(second_sum.u128() > deposit_amount - max_fee.u128());
 
     Ok(())
 }

--- a/contracts/savings-app/tests/interface.rs
+++ b/contracts/savings-app/tests/interface.rs
@@ -49,7 +49,7 @@ use osmosis_std::types::osmosis::{
 use prost::Message;
 use prost_types::Any;
 
-fn assert_is_around(result: Uint128, expected: impl Into<Uint128>) -> anyhow::Result<()> {
+pub fn assert_is_around(result: Uint128, expected: impl Into<Uint128>) -> anyhow::Result<()> {
     let expected = expected.into().u128();
     let result = result.u128();
 
@@ -61,11 +61,11 @@ fn assert_is_around(result: Uint128, expected: impl Into<Uint128>) -> anyhow::Re
     Ok(())
 }
 
-fn factory_denom<Chain: CwEnv>(chain: &Chain, subdenom: &str) -> String {
+pub fn factory_denom<Chain: CwEnv>(chain: &Chain, subdenom: &str) -> String {
     format!("factory/{}/{}", chain.sender(), subdenom)
 }
 
-fn create_denom<Chain: CwEnv + Stargate>(chain: Chain, subdenom: String) -> anyhow::Result<()> {
+pub fn create_denom<Chain: CwEnv + Stargate>(chain: Chain, subdenom: String) -> anyhow::Result<()> {
     chain.commit_any::<MsgCreateDenomResponse>(
         vec![Any {
             value: MsgCreateDenom {
@@ -83,7 +83,7 @@ fn create_denom<Chain: CwEnv + Stargate>(chain: Chain, subdenom: String) -> anyh
 
 pub const LOTS: u128 = 100_000_000_000_000;
 
-fn mint_lots_of_denom<Chain: CwEnv + Stargate>(
+pub fn mint_lots_of_denom<Chain: CwEnv + Stargate>(
     chain: Chain,
     subdenom: String,
 ) -> anyhow::Result<()> {
@@ -106,8 +106,6 @@ fn mint_lots_of_denom<Chain: CwEnv + Stargate>(
 pub const USDC: &str = "USDC";
 pub const USDT: &str = "USDT";
 pub const DEX_NAME: &str = "osmosis";
-pub const VAULT_NAME: &str = "quasar_vault";
-pub const VAULT_SUBDENOM: &str = "vault-token";
 
 pub const TICK_SPACING: u64 = 100;
 pub const SPREAD_FACTOR: u64 = 1;
@@ -211,7 +209,7 @@ pub fn deploy<Chain: CwEnv + Stargate>(
     Ok(savings_app)
 }
 
-fn create_position<Chain: CwEnv>(
+pub fn create_position<Chain: CwEnv>(
     app: &Application<Chain, app::AppInterface<Chain>>,
     funds: Vec<Coin>,
     asset0: Coin,
@@ -231,7 +229,7 @@ fn create_position<Chain: CwEnv>(
     Ok(())
 }
 
-fn create_pool(chain: OsmosisTestTube) -> anyhow::Result<u64> {
+pub fn create_pool(chain: OsmosisTestTube) -> anyhow::Result<u64> {
     // We create two tokenfactory denoms
     create_denom(chain.clone(), USDC.to_string())?;
     create_denom(chain.clone(), USDT.to_string())?;
@@ -306,7 +304,7 @@ fn create_pool(chain: OsmosisTestTube) -> anyhow::Result<u64> {
     Ok(pool.id)
 }
 
-fn setup_test_tube(
+pub fn setup_test_tube(
     create_position: bool,
 ) -> anyhow::Result<(
     u64,
@@ -337,7 +335,7 @@ fn setup_test_tube(
     Ok((pool_id, savings_app))
 }
 
-fn give_authorizations<Chain: CwEnv + Stargate>(
+pub fn give_authorizations<Chain: CwEnv + Stargate>(
     client: &AbstractClient<Chain>,
     savings_app_addr: String,
 ) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
This PR aims at adding a simple test for double create-position to make sure the position is succesfully created even after a second creation.


## Issue

The logic is not perfect because the position is not recomputed according to the actual funds distribution after withdraw and instead is a little off. 

Creating a large position to simulate the actual pool weight might change that