### PR TITLE
add-version-label

### DIFF
--- a/bot/src/metrics.rs
+++ b/bot/src/metrics.rs
@@ -58,7 +58,7 @@ impl Metrics {
                 "carrot_app_bot_contract_balance",
                 "Funds managed by a specific carrot instance",
             ),
-            &["contract_address"],
+            &["contract_address", "contract_version"],
         )
         .unwrap();
         registry.register(Box::new(fetch_count.clone())).unwrap();


### PR DESCRIPTION
This allows to capture the version of every contract with the respective balances as I am working on this ticket 
https://linear.app/abstract-sdk/issue/DAT-48/monitor-the-fleet-version-drift 