### PR TITLE
add the possibility to find what versions are succeeding in autocompo…

### DIFF
--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -71,7 +71,7 @@ pub struct Bot {
     fetch_contracts_cooldown: Duration,
     last_fetch: SystemTime,
     // Autocompound information
-    contract_instances_to_ac: HashSet<(String, CarrotInstancee)>,
+    contract_instances_to_ac: HashSet<(String, CarrotInstance)>,
     // Used for APR calculation
     apr_reference_contract: Addr,
     pub autocompound_cooldown: Duration,
@@ -80,11 +80,11 @@ pub struct Bot {
 }
 
 #[derive(Eq, Hash, PartialEq, Clone)]
-struct CarrotInstancee {
+struct CarrotInstance {
     address: Addr,
     version: String,
 }
-impl CarrotInstancee {
+impl CarrotInstance {
     fn new(address: Addr, version: &str) -> Self {
         Self {
             address,
@@ -93,11 +93,11 @@ impl CarrotInstancee {
     }
 }
 
-impl Display for CarrotInstancee {
+impl Display for CarrotInstance {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "CarrotInstancee {{ address: {:?}, version: {} }}",
+            "CarrotInstance {{ address: {:?}, version: {} }}",
             self.address, self.version
         )
     }
@@ -154,7 +154,7 @@ impl Bot {
         let daemon = &self.daemon;
 
         let abstr = AbstractClient::new(self.daemon.clone())?;
-        let mut contract_instances_to_autocompound: HashSet<(String, CarrotInstancee)> =
+        let mut contract_instances_to_autocompound: HashSet<(String, CarrotInstance)> =
             HashSet::new();
 
         log!(Level::Debug, "Fetching modules");
@@ -239,7 +239,7 @@ impl Bot {
             contract_instances_to_autocompound.extend(contract_addrs.into_iter().map(|addr| {
                 (
                     app_info.module.info.id(),
-                    CarrotInstancee::new(Addr::unchecked(addr), version.as_ref()),
+                    CarrotInstance::new(Addr::unchecked(addr), version.as_ref()),
                 )
             }));
         }

--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -261,8 +261,7 @@ impl Bot {
         for (id, contract) in self.contract_instances_to_ac.iter() {
             let version = &contract.version;
             let addr = &contract.address;
-            let label =
-                labels! {"contract_address"=> addr.as_ref(),"contract_version"=> version.as_ref()};
+            let label = labels! {"contract_version"=> version.as_ref()};
             let result = autocompound_instance(&self.daemon, (id, &addr));
             if let Err(err) = result {
                 log!(

--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -34,6 +34,7 @@ use osmosis_std::types::{
 use prometheus::{labels, Registry};
 use std::{
     collections::HashSet,
+    fmt::{Display, Formatter},
     time::{Duration, SystemTime},
 };
 use tonic::transport::Channel;
@@ -70,12 +71,36 @@ pub struct Bot {
     fetch_contracts_cooldown: Duration,
     last_fetch: SystemTime,
     // Autocompound information
-    contract_instances_to_ac: HashSet<(String, Addr)>,
+    contract_instances_to_ac: HashSet<(String, CarrotInstancee)>,
     // Used for APR calculation
     apr_reference_contract: Addr,
     pub autocompound_cooldown: Duration,
     // metrics
     metrics: Metrics,
+}
+
+#[derive(Eq, Hash, PartialEq, Clone)]
+struct CarrotInstancee {
+    address: Addr,
+    version: String,
+}
+impl CarrotInstancee {
+    fn new(address: Addr, version: &str) -> Self {
+        Self {
+            address,
+            version: version.to_string(),
+        }
+    }
+}
+
+impl Display for CarrotInstancee {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CarrotInstancee {{ address: {:?}, version: {} }}",
+            self.address, self.version
+        )
+    }
 }
 
 struct Balance {
@@ -129,7 +154,8 @@ impl Bot {
         let daemon = &self.daemon;
 
         let abstr = AbstractClient::new(self.daemon.clone())?;
-        let mut contract_instances_to_autocompound: HashSet<(String, Addr)> = HashSet::new();
+        let mut contract_instances_to_autocompound: HashSet<(String, CarrotInstancee)> =
+            HashSet::new();
 
         log!(Level::Debug, "Fetching modules");
         let saving_modules = abstr.version_control().module_list(
@@ -210,11 +236,12 @@ impl Bot {
             });
 
             // Add all the entries to the `contract_instances_to_check`
-            contract_instances_to_autocompound.extend(
-                contract_addrs
-                    .into_iter()
-                    .map(|addr| (app_info.module.info.id(), Addr::unchecked(addr))),
-            );
+            contract_instances_to_autocompound.extend(contract_addrs.into_iter().map(|addr| {
+                (
+                    app_info.module.info.id(),
+                    CarrotInstancee::new(Addr::unchecked(addr), version.as_ref()),
+                )
+            }));
         }
 
         // Metrics
@@ -222,8 +249,7 @@ impl Bot {
         self.metrics
             .fetch_instances_count
             .set(fetch_instances_count as i64);
-        self.contract_instances_to_ac
-            .clone_from(&contract_instances_to_autocompound);
+        self.contract_instances_to_ac = contract_instances_to_autocompound.clone();
         self.metrics
             .contract_instances_to_autocompound
             .set(contract_instances_to_autocompound.len() as i64);
@@ -232,13 +258,20 @@ impl Bot {
 
     // Autocompound all saved instances and wait for cooldown duration
     pub fn autocompound(&self) {
-        for (id, addr) in self.contract_instances_to_ac.iter() {
-            let result = autocompound_instance(&self.daemon, (id, addr));
+        for (id, contract) in self.contract_instances_to_ac.iter() {
+            let version = &contract.version;
+            let addr = &contract.address;
+            let label =
+                labels! {"contract_address"=> addr.as_ref(),"contract_version"=> version.as_ref()};
+            let result = autocompound_instance(&self.daemon, (id, &addr));
             if let Err(err) = result {
-                log!(Level::Error, "error ocurred for {addr} carrot-app: {err:?}");
-                self.metrics.autocompounded_error_count.inc();
+                log!(
+                    Level::Error,
+                    "error ocurred for {contract} carrot-app: {err:?}"
+                );
+                self.metrics.autocompounded_error_count.with(&label).inc();
             } else {
-                self.metrics.autocompounded_count.inc();
+                self.metrics.autocompounded_count.with(&label).inc();
             }
         }
     }

--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -249,7 +249,8 @@ impl Bot {
         self.metrics
             .fetch_instances_count
             .set(fetch_instances_count as i64);
-        self.contract_instances_to_ac = contract_instances_to_autocompound.clone();
+        self.contract_instances_to_ac
+            .clone_from(&contract_instances_to_autocompound);
         self.metrics
             .contract_instances_to_autocompound
             .set(contract_instances_to_autocompound.len() as i64);

--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -262,7 +262,7 @@ impl Bot {
             let version = &contract.version;
             let addr = &contract.address;
             let label = labels! {"contract_version"=> version.as_ref()};
-            let result = autocompound_instance(&self.daemon, (id, &addr));
+            let result = autocompound_instance(&self.daemon, (id, addr));
             if let Err(err) = result {
                 log!(
                     Level::Error,

--- a/bot/src/metrics.rs
+++ b/bot/src/metrics.rs
@@ -1,12 +1,14 @@
-use prometheus::{Encoder, IntCounter, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder};
+use prometheus::{
+    Encoder, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder,
+};
 
 use warp::Filter;
 
 pub struct Metrics {
     pub fetch_count: IntCounter,
     pub fetch_instances_count: IntGauge,
-    pub autocompounded_count: IntCounter,
-    pub autocompounded_error_count: IntCounter,
+    pub autocompounded_count: IntCounterVec,
+    pub autocompounded_error_count: IntCounterVec,
     pub contract_instances_to_autocompound: IntGauge,
     // Total value locked by all instance
     pub total_value_locked: IntGauge,
@@ -28,14 +30,20 @@ impl Metrics {
             "Number of fetched instances",
         )
         .unwrap();
-        let autocompounded_count = IntCounter::new(
-            "carrot_app_bot_autocompounded_count",
-            "Number of times contracts have been autocompounded",
+        let autocompounded_count = IntCounterVec::new(
+            Opts::new(
+                "carrot_app_bot_autocompounded_count",
+                "Number of times contracts have been autocompounded",
+            ),
+            &["contract_address", "contract_version"],
         )
         .unwrap();
-        let autocompounded_error_count = IntCounter::new(
-            "carrot_app_bot_autocompounded_error_count",
-            "Number of times autocompounding errored",
+        let autocompounded_error_count = IntCounterVec::new(
+            Opts::new(
+                "carrot_app_bot_autocompounded_error_count",
+                "Number of times autocompounding errored",
+            ),
+            &["contract_address", "contract_version"],
         )
         .unwrap();
         let contract_instances_to_autocompound = IntGauge::new(

--- a/bot/src/metrics.rs
+++ b/bot/src/metrics.rs
@@ -35,7 +35,7 @@ impl Metrics {
                 "carrot_app_bot_autocompounded_count",
                 "Number of times contracts have been autocompounded",
             ),
-            &["contract_address", "contract_version"],
+            &["contract_version"],
         )
         .unwrap();
         let autocompounded_error_count = IntCounterVec::new(
@@ -43,7 +43,7 @@ impl Metrics {
                 "carrot_app_bot_autocompounded_error_count",
                 "Number of times autocompounding errored",
             ),
-            &["contract_address", "contract_version"],
+            &["contract_version"],
         )
         .unwrap();
         let contract_instances_to_autocompound = IntGauge::new(


### PR DESCRIPTION
…und and what versions are failing

With this new addition we can know which versions are causing issues in autocompounding, and we can even dive deepter and see what instances fail and what instances succeed. This should be very helpful in the future.