### PR TITLE
Update config

### DIFF
--- a/contracts/carrot-app/src/msg.rs
+++ b/contracts/carrot-app/src/msg.rs
@@ -44,6 +44,11 @@ pub struct CreatePositionMessage {
 #[cfg_attr(feature = "interface", derive(cw_orch::ExecuteFns))]
 #[cfg_attr(feature = "interface", impl_into(ExecuteMsg))]
 pub enum AppExecuteMsg {
+    /// Update autocompound settings
+    UpdateConfig {
+        autocompound_cooldown_seconds: Option<Uint64>,
+        autocompound_rewards_config: Option<AutocompoundRewardsConfig>,
+    },
     /// Create the initial liquidity position
     CreatePosition(CreatePositionMessage),
     /// Deposit funds onto the app


### PR DESCRIPTION
We currently don't have a way to update autocompound config(cooldown or rewards) after app install, this PR adds update_config method to solve it
Closes MOD-40