### PR TITLE
Fix bot drain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ abstract-app = { version = "0.21.0" }
 abstract-interface = { version = "0.21.0" }
 abstract-dex-adapter = { git = "https://github.com/abstractsdk/abstract.git", tag = "v0.21.0" }
 abstract-client = { version = "0.21.0" }
+cw-asset = { version = "3.0" }

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -26,3 +26,4 @@ prometheus = "0.13.2"
 tokio = "1.26.0"
 warp = "0.3.6"
 semver = "1.0"
+cw-asset = { workspace = true }

--- a/contracts/carrot-app/Cargo.toml
+++ b/contracts/carrot-app/Cargo.toml
@@ -45,7 +45,7 @@ cw-controllers = { version = "1.0.1" }
 cw-storage-plus = "1.2.0"
 thiserror = { version = "1.0.50" }
 schemars = "0.8"
-cw-asset = { version = "3.0" }
+cw-asset = { workspace = true }
 
 abstract-app = { workspace = true }
 abstract-sdk = { version = "0.21.0", features = ["stargate"] }


### PR DESCRIPTION
Currently bot autocompounds every contract every hour, but it should only do it after cooldown, this PR fixes it
Closes MOD-43