### PR TITLE
Fix autocompound in case of only incentives

### DIFF
--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savings-bot"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -44,7 +44,7 @@ use abstract_app::{
     objects::module::{ModuleInfo, ModuleStatus},
 };
 
-const VERSION_REQ: &str = ">=0.2";
+const VERSION_REQ: &str = ">=0.3";
 
 const AUTHORIZATION_URLS: &[&str] = &[
     MsgCreatePosition::TYPE_URL,
@@ -254,7 +254,7 @@ fn autocompound_instance(daemon: &Daemon, instance: (&str, &Addr)) -> anyhow::Re
     // TODO: ensure rewards > tx fee
 
     // Ensure there is rewards and pool rewards not empty
-    if resp.autocompound_reward_available && !resp.pool_rewards.is_empty() {
+    if resp.autocompound_reward_available && !resp.spread_rewards.is_empty() {
         // Execute autocompound
         daemon.execute(
             &ExecuteMsg::from(AppExecuteMsg::Autocompound {}),

--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -286,7 +286,7 @@ fn autocompound_instance(daemon: &Daemon, instance: (&str, &Addr)) -> anyhow::Re
 
     // Ensure contract is ready for autocompound,
     // user can send rewards,
-    // pool rewards not empty
+    // spread rewards not empty
     // and bot will get paid enough to cover gas fees
     if resp.status.is_ready()
         && resp.autocompound_reward_available

--- a/contracts/carrot-app/Cargo.toml
+++ b/contracts/carrot-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carrot-app"
-version = "0.2.1"
+version = "0.3.0"
 authors = [
   "CyberHoward <cyberhoward@protonmail.com>",
   "Adair <adair@abstract.money>",

--- a/contracts/carrot-app/src/msg.rs
+++ b/contracts/carrot-app/src/msg.rs
@@ -104,7 +104,8 @@ pub struct CompoundStatusResponse {
     pub autocompound_reward: AssetBase<String>,
     /// Wether user have enough balance to reward or can swap to get enough
     pub autocompound_reward_available: bool,
-    pub pool_rewards: Vec<Coin>,
+    pub spread_rewards: Vec<Coin>,
+    pub incentives: Vec<Coin>,
 }
 
 #[cw_serde]

--- a/contracts/carrot-app/tests/autocompound.rs
+++ b/contracts/carrot-app/tests/autocompound.rs
@@ -79,9 +79,11 @@ fn check_autocompound() -> anyhow::Result<()> {
 
     // Check autocompound adds liquidity from the rewards and user balance remain unchanged
 
+    // Check we have rewards
     // Check it has some rewards to autocompound first
-    let rewards = carrot_app.compound_status()?.pool_rewards;
-    assert!(rewards.iter().any(|c| c.denom == GAS_DENOM));
+    let status = carrot_app.compound_status()?;
+    assert!(!status.spread_rewards.is_empty());
+    assert!(status.incentives.iter().any(|c| c.denom == GAS_DENOM));
 
     // Save balances
     let balance_before_autocompound: AssetsBalanceResponse = carrot_app.balance()?;
@@ -119,8 +121,9 @@ fn check_autocompound() -> anyhow::Result<()> {
     assert!(balance_usdc_after_autocompound.amount >= balance_usdc_before_autocompound.amount);
     assert!(balance_usdt_after_autocompound.amount >= balance_usdt_before_autocompound.amount,);
     // Check it used all of the rewards
-    let rewards = carrot_app.compound_status()?.pool_rewards;
-    assert!(rewards.is_empty());
+    let status = carrot_app.compound_status()?;
+    assert!(status.spread_rewards.is_empty());
+    assert!(status.incentives.is_empty());
 
     Ok(())
 }
@@ -190,8 +193,9 @@ fn stranger_autocompound() -> anyhow::Result<()> {
     // and rewards gets passed to the "stranger"
 
     // Check it has some rewards to autocompound first
-    let pool_rewards = carrot_app.compound_status()?.pool_rewards;
-    assert!(pool_rewards.iter().any(|c| c.denom == GAS_DENOM));
+    let status = carrot_app.compound_status()?;
+    assert!(!status.spread_rewards.is_empty());
+    assert!(status.incentives.iter().any(|c| c.denom == GAS_DENOM));
 
     // Save balances
     let balance_before_autocompound: AssetsBalanceResponse = carrot_app.balance()?;
@@ -215,8 +219,9 @@ fn stranger_autocompound() -> anyhow::Result<()> {
     assert!(balance_after_autocompound.liquidity > balance_before_autocompound.liquidity);
 
     // Check it used all of the rewards
-    let rewards = carrot_app.compound_status()?.pool_rewards;
-    assert!(rewards.is_empty());
+    let status = carrot_app.compound_status()?;
+    assert!(status.incentives.is_empty());
+    assert!(status.spread_rewards.is_empty());
 
     // Check stranger gets rewarded
     let stranger_reward_balance = chain.query_balance(stranger.address().as_str(), REWARD_DENOM)?;


### PR DESCRIPTION
This PR fixes cases where contract returns non-empty pool rewards list, but it includes only incentives. Fix done by separating spread and incentives in response