### PR TITLE
Fix compound status query

### DIFF
--- a/contracts/carrot-app/src/error.rs
+++ b/contracts/carrot-app/src/error.rs
@@ -60,11 +60,6 @@ pub enum AppError {
     #[error("No rewards for autocompound")]
     NoRewards {},
 
-    #[error(
-        "Failed to query position with id {0}, perhaps it got withdrawn outside of a contract: {1}. Use create_position for a new position"
-    )]
-    UnableToQueryPosition(u64, StdError),
-
     #[error("Reward configuration error: {0}")]
     RewardConfigError(String),
 

--- a/contracts/carrot-app/src/handlers/execute.rs
+++ b/contracts/carrot-app/src/handlers/execute.rs
@@ -289,10 +289,11 @@ fn autocompound(deps: DepsMut, env: Env, info: MessageInfo, app: App) -> AppResu
     let config = CONFIG.load(deps.storage)?;
     if !app.admin.is_admin(deps.as_ref(), &info.sender)?
         && get_position_status(
-            deps.storage,
+            deps.as_ref(),
             &env,
             config.autocompound_cooldown_seconds.u64(),
         )?
+        .0
         .is_ready()
     {
         let executor_reward_messages = autocompound_executor_rewards(

--- a/contracts/carrot-app/src/msg.rs
+++ b/contracts/carrot-app/src/msg.rs
@@ -122,6 +122,8 @@ pub enum CompoundStatus {
     Cooldown(Uint64),
     /// No open position right now
     NoPosition {},
+    /// Position exists in state, but errors on query to the pool
+    PositionNotAvailable(u64),
 }
 
 impl CompoundStatus {

--- a/contracts/carrot-app/tests/deposit_withdraw.rs
+++ b/contracts/carrot-app/tests/deposit_withdraw.rs
@@ -1,7 +1,9 @@
 mod common;
 
 use crate::common::{create_position, setup_test_tube, USDC, USDT};
-use carrot_app::msg::{AppExecuteMsgFns, AppQueryMsgFns, AssetsBalanceResponse, PositionResponse};
+use carrot_app::msg::{
+    AppExecuteMsgFns, AppQueryMsgFns, AssetsBalanceResponse, CompoundStatus, PositionResponse,
+};
 use cosmwasm_std::{coin, coins, Decimal, Uint128};
 use cw_orch::{
     anyhow,
@@ -187,6 +189,13 @@ fn withdraw_after_user_withdraw_liquidity_manually() -> anyhow::Result<()> {
 
     // Ensure it errors
     carrot_app.withdraw_all().unwrap_err();
+
+    // Ensure we get correct compound response
+    let status_response = carrot_app.compound_status()?;
+    assert_eq!(
+        status_response.status,
+        CompoundStatus::PositionNotAvailable(position_id)
+    );
 
     // Ensure position deleted
     let position_not_found = cl

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -61,6 +61,42 @@
       "description": "App execute messages",
       "oneOf": [
         {
+          "description": "Update autocompound settings",
+          "type": "object",
+          "required": [
+            "update_config"
+          ],
+          "properties": {
+            "update_config": {
+              "type": "object",
+              "properties": {
+                "autocompound_cooldown_seconds": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Uint64"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "autocompound_rewards_config": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/AutocompoundRewardsConfig"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
           "description": "Create the initial liquidity position",
           "type": "object",
           "required": [
@@ -180,6 +216,10 @@
         }
       ]
     },
+    "AssetEntry": {
+      "description": "An unchecked ANS asset entry. This is a string that is formatted as `src_chain>[intermediate_chain>]asset_name`",
+      "type": "string"
+    },
     "Attribute": {
       "description": "An key value pair that is used in the context of event attributes in logs",
       "type": "object",
@@ -195,6 +235,60 @@
           "type": "string"
         }
       }
+    },
+    "AutocompoundRewardsConfig": {
+      "description": "Configuration on how rewards should be distributed to the address who helped to execute autocompound",
+      "type": "object",
+      "required": [
+        "gas_asset",
+        "max_gas_balance",
+        "min_gas_balance",
+        "reward",
+        "swap_asset"
+      ],
+      "properties": {
+        "gas_asset": {
+          "description": "Gas denominator for this chain",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AssetEntry"
+            }
+          ]
+        },
+        "max_gas_balance": {
+          "description": "Upper bound of gas tokens expected after the swap",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        },
+        "min_gas_balance": {
+          "description": "If gas token balance falls below this bound a swap will be generated",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        },
+        "reward": {
+          "description": "Reward amount",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        },
+        "swap_asset": {
+          "description": "Denominator of the asset that will be used for swap to the gas asset",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AssetEntry"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "BaseExecuteMsg": {
       "oneOf": [

--- a/schema/module-schema.json
+++ b/schema/module-schema.json
@@ -210,6 +210,42 @@
     "description": "App execute messages",
     "oneOf": [
       {
+        "description": "Update autocompound settings",
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "properties": {
+              "autocompound_cooldown_seconds": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Uint64"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "autocompound_rewards_config": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/AutocompoundRewardsConfig"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Create the initial liquidity position",
         "type": "object",
         "required": [
@@ -329,6 +365,64 @@
       }
     ],
     "definitions": {
+      "AssetEntry": {
+        "description": "An unchecked ANS asset entry. This is a string that is formatted as `src_chain>[intermediate_chain>]asset_name`",
+        "type": "string"
+      },
+      "AutocompoundRewardsConfig": {
+        "description": "Configuration on how rewards should be distributed to the address who helped to execute autocompound",
+        "type": "object",
+        "required": [
+          "gas_asset",
+          "max_gas_balance",
+          "min_gas_balance",
+          "reward",
+          "swap_asset"
+        ],
+        "properties": {
+          "gas_asset": {
+            "description": "Gas denominator for this chain",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AssetEntry"
+              }
+            ]
+          },
+          "max_gas_balance": {
+            "description": "Upper bound of gas tokens expected after the swap",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              }
+            ]
+          },
+          "min_gas_balance": {
+            "description": "If gas token balance falls below this bound a swap will be generated",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              }
+            ]
+          },
+          "reward": {
+            "description": "Reward amount",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              }
+            ]
+          },
+          "swap_asset": {
+            "description": "Denominator of the asset that will be used for swap to the gas asset",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AssetEntry"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
       "Coin": {
         "type": "object",
         "required": [
@@ -418,6 +512,10 @@
       },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
         "type": "string"
       }
     }
@@ -539,7 +637,8 @@
       "required": [
         "autocompound_reward",
         "autocompound_reward_available",
-        "pool_rewards",
+        "incentives",
+        "spread_rewards",
         "status"
       ],
       "properties": {
@@ -550,7 +649,13 @@
           "description": "Wether user have enough balance to reward or can swap to get enough",
           "type": "boolean"
         },
-        "pool_rewards": {
+        "incentives": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coin"
+          }
+        },
+        "spread_rewards": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Coin"
@@ -673,6 +778,21 @@
                 "no_position": {
                   "type": "object",
                   "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Position exists in state, but errors on query to the pool",
+              "type": "object",
+              "required": [
+                "position_not_available"
+              ],
+              "properties": {
+                "position_not_available": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
                 }
               },
               "additionalProperties": false

--- a/schema/raw/execute.json
+++ b/schema/raw/execute.json
@@ -4,6 +4,42 @@
   "description": "App execute messages",
   "oneOf": [
     {
+      "description": "Update autocompound settings",
+      "type": "object",
+      "required": [
+        "update_config"
+      ],
+      "properties": {
+        "update_config": {
+          "type": "object",
+          "properties": {
+            "autocompound_cooldown_seconds": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint64"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "autocompound_rewards_config": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AutocompoundRewardsConfig"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Create the initial liquidity position",
       "type": "object",
       "required": [
@@ -123,6 +159,64 @@
     }
   ],
   "definitions": {
+    "AssetEntry": {
+      "description": "An unchecked ANS asset entry. This is a string that is formatted as `src_chain>[intermediate_chain>]asset_name`",
+      "type": "string"
+    },
+    "AutocompoundRewardsConfig": {
+      "description": "Configuration on how rewards should be distributed to the address who helped to execute autocompound",
+      "type": "object",
+      "required": [
+        "gas_asset",
+        "max_gas_balance",
+        "min_gas_balance",
+        "reward",
+        "swap_asset"
+      ],
+      "properties": {
+        "gas_asset": {
+          "description": "Gas denominator for this chain",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AssetEntry"
+            }
+          ]
+        },
+        "max_gas_balance": {
+          "description": "Upper bound of gas tokens expected after the swap",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        },
+        "min_gas_balance": {
+          "description": "If gas token balance falls below this bound a swap will be generated",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        },
+        "reward": {
+          "description": "Reward amount",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        },
+        "swap_asset": {
+          "description": "Denominator of the asset that will be used for swap to the gas asset",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AssetEntry"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "Coin": {
       "type": "object",
       "required": [
@@ -212,6 +306,10 @@
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
       "type": "string"
     }
   }

--- a/schema/raw/response_to_compound_status.json
+++ b/schema/raw/response_to_compound_status.json
@@ -5,7 +5,8 @@
   "required": [
     "autocompound_reward",
     "autocompound_reward_available",
-    "pool_rewards",
+    "incentives",
+    "spread_rewards",
     "status"
   ],
   "properties": {
@@ -16,7 +17,13 @@
       "description": "Wether user have enough balance to reward or can swap to get enough",
       "type": "boolean"
     },
-    "pool_rewards": {
+    "incentives": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Coin"
+      }
+    },
+    "spread_rewards": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/Coin"
@@ -139,6 +146,21 @@
             "no_position": {
               "type": "object",
               "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Position exists in state, but errors on query to the pool",
+          "type": "object",
+          "required": [
+            "position_not_available"
+          ],
+          "properties": {
+            "position_not_available": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
This PR removes `UnableToQueryPosition` error type that was getting returned on failed osmosis `position_by_id` query.
To compensate that `PositionNotAvailable(position_id)` status of compound was added, meaning `query_compound_status` now doesn't error on failed osmosis query
Beyond that added few gas optimization, to avoid multiple queries of the same data.
See [MOD-44](https://linear.app/abstract-sdk/issue/MOD-44/fix-autocompound-query-not-accounting-for-manual-withdraw)