### PR TITLE
Fix deposit of shifted positions

### DIFF
--- a/contracts/carrot-app/src/handlers/execute.rs
+++ b/contracts/carrot-app/src/handlers/execute.rs
@@ -2,7 +2,7 @@ use super::swap_helpers::{swap_msg, swap_to_enter_position};
 use crate::{
     contract::{App, AppResult, OSMOSIS},
     error::AppError,
-    helpers::{get_balance, get_user},
+    helpers::{cosmwasm_to_proto_coins_sorted, get_balance, get_user},
     msg::{AppExecuteMsg, CreatePositionMessage, ExecuteMsg},
     replies::{ADD_TO_POSITION_ID, CREATE_POSITION_ID},
     state::{
@@ -20,7 +20,7 @@ use cosmwasm_std::{
 };
 use cw_asset::Asset;
 use osmosis_std::{
-    cosmwasm_to_proto_coins, try_proto_to_cosmwasm_coins,
+    try_proto_to_cosmwasm_coins,
     types::osmosis::concentratedliquidity::v1beta1::{
         FullPositionBreakdown, MsgAddToPosition, MsgCollectIncentives, MsgCollectSpreadRewards,
         MsgCreatePosition, MsgWithdrawPosition, Position,
@@ -501,7 +501,7 @@ pub(crate) fn _create_position(
     let sender = get_user(deps, app)?;
 
     // 2. Create a position
-    let tokens = cosmwasm_to_proto_coins(resulting_assets);
+    let tokens_provided = cosmwasm_to_proto_coins_sorted(resulting_assets);
     let create_msg = app.auth_z(deps, Some(sender.clone()))?.execute(
         &env.contract.address,
         MsgCreatePosition {
@@ -509,7 +509,7 @@ pub(crate) fn _create_position(
             sender: sender.to_string(),
             lower_tick,
             upper_tick,
-            tokens_provided: tokens,
+            tokens_provided,
             token_min_amount0: "0".to_string(),
             token_min_amount1: "0".to_string(),
         },

--- a/contracts/carrot-app/src/handlers/swap_helpers.rs
+++ b/contracts/carrot-app/src/handlers/swap_helpers.rs
@@ -148,7 +148,6 @@ pub(crate) fn tokens_to_swap(
         )
     };
 
-    // TODO, compute the resulting balance to be able to deposit back into the pool
     Ok((offer_asset, ask_asset, assets_for_position))
 }
 

--- a/contracts/carrot-app/src/handlers/swap_helpers.rs
+++ b/contracts/carrot-app/src/handlers/swap_helpers.rs
@@ -2,6 +2,7 @@ use abstract_app::objects::{AnsAsset, AssetEntry};
 use abstract_dex_adapter::{msg::GenerateMessagesResponse, DexInterface};
 use abstract_sdk::AuthZInterface;
 use cosmwasm_std::{Coin, CosmosMsg, Decimal, Deps, Env, Uint128};
+use osmosis_std::cosmwasm_to_proto_coins;
 const MAX_SPREAD_PERCENT: u64 = 20;
 pub const DEFAULT_SLIPPAGE: Decimal = Decimal::permille(5);
 
@@ -12,6 +13,23 @@ use crate::{
 };
 
 use super::query::query_price;
+
+/// Assets to be included to the position
+pub struct AssetsForPosition {
+    pub asset0: Coin,
+    pub asset1: Coin,
+}
+
+impl Into<Vec<osmosis_std::types::cosmos::base::v1beta1::Coin>> for AssetsForPosition {
+    fn into(self) -> Vec<osmosis_std::types::cosmos::base::v1beta1::Coin> {
+        // Need to have it sorted
+        let coins = match self.asset0.denom.cmp(&self.asset1.denom) {
+            std::cmp::Ordering::Less => [self.asset0, self.asset1],
+            _ => [self.asset1, self.asset0],
+        };
+        cosmwasm_to_proto_coins(coins)
+    }
+}
 
 pub(crate) fn swap_msg(
     deps: Deps,
@@ -49,7 +67,7 @@ pub(crate) fn tokens_to_swap(
     asset0: Coin, // Represents the amount of Coin 0 we would like the position to handle
     asset1: Coin, // Represents the amount of Coin 1 we would like the position to handle,
     price: Decimal, // Relative price (when swapping amount0 for amount1, equals amount0/amount1)
-) -> AppResult<(AnsAsset, AssetEntry, Vec<Coin>)> {
+) -> AppResult<(AnsAsset, AssetEntry, AssetsForPosition)> {
     let config = CONFIG.load(deps.storage)?;
 
     let x0 = amount_to_swap
@@ -89,7 +107,7 @@ pub(crate) fn tokens_to_swap(
     let x0_a1 = x0.amount * asset1.amount;
     let x1_a0 = x1.amount * asset0.amount;
 
-    let (offer_asset, ask_asset, resulting_balance) = if x0_a1 < x1_a0 {
+    let (offer_asset, ask_asset, assets_for_position) = if x0_a1 < x1_a0 {
         let numerator = x1_a0 - x0_a1;
         let denominator = asset0.amount + price * asset1.amount;
         let y1 = numerator / denominator;
@@ -97,16 +115,16 @@ pub(crate) fn tokens_to_swap(
         (
             AnsAsset::new(config.pool_config.asset1, y1),
             config.pool_config.asset0,
-            vec![
-                Coin {
+            AssetsForPosition {
+                asset0: Coin {
                     amount: x0.amount + price * y1,
                     denom: x0.denom,
                 },
-                Coin {
+                asset1: Coin {
                     amount: x1.amount - y1,
                     denom: x1.denom,
                 },
-            ],
+            },
         )
     } else {
         let numerator = x0_a1 - x1_a0;
@@ -117,21 +135,21 @@ pub(crate) fn tokens_to_swap(
         (
             AnsAsset::new(config.pool_config.asset0, numerator / denominator),
             config.pool_config.asset1,
-            vec![
-                Coin {
+            AssetsForPosition {
+                asset0: Coin {
                     amount: x0.amount - y0,
                     denom: x0.denom,
                 },
-                Coin {
+                asset1: Coin {
                     amount: x1.amount + Decimal::from_ratio(y0, 1u128) / price * Uint128::one(),
                     denom: x1.denom,
                 },
-            ],
+            },
         )
     };
 
     // TODO, compute the resulting balance to be able to deposit back into the pool
-    Ok((offer_asset, ask_asset, resulting_balance))
+    Ok((offer_asset, ask_asset, assets_for_position))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -145,14 +163,14 @@ pub fn swap_to_enter_position(
     max_spread: Option<Decimal>,
     belief_price0: Option<Decimal>,
     belief_price1: Option<Decimal>,
-) -> AppResult<(Vec<CosmosMsg>, Vec<Coin>)> {
+) -> AppResult<(Vec<CosmosMsg>, AssetsForPosition)> {
     let price = query_price(deps, &funds, app, max_spread, belief_price0, belief_price1)?;
-    let (offer_asset, ask_asset, resulting_assets) =
+    let (offer_asset, ask_asset, assets_for_position) =
         tokens_to_swap(deps, funds, asset0, asset1, price)?;
 
     Ok((
         swap_msg(deps, env, offer_asset, ask_asset, app)?,
-        resulting_assets,
+        assets_for_position,
     ))
 }
 

--- a/contracts/carrot-app/src/handlers/swap_helpers.rs
+++ b/contracts/carrot-app/src/handlers/swap_helpers.rs
@@ -20,12 +20,11 @@ pub struct AssetsForPosition {
     pub asset1: Coin,
 }
 
-impl Into<Vec<osmosis_std::types::cosmos::base::v1beta1::Coin>> for AssetsForPosition {
-    fn into(self) -> Vec<osmosis_std::types::cosmos::base::v1beta1::Coin> {
-        // Need to have it sorted
-        let coins = match self.asset0.denom.cmp(&self.asset1.denom) {
-            std::cmp::Ordering::Less => [self.asset0, self.asset1],
-            _ => [self.asset1, self.asset0],
+impl From<AssetsForPosition> for Vec<osmosis_std::types::cosmos::base::v1beta1::Coin> {
+    fn from(value: AssetsForPosition) -> Self {
+        let coins = match value.asset0.denom.cmp(&value.asset1.denom) {
+            std::cmp::Ordering::Less => [value.asset0, value.asset1],
+            _ => [value.asset1, value.asset0],
         };
         cosmwasm_to_proto_coins(coins)
     }

--- a/contracts/carrot-app/src/handlers/swap_helpers.rs
+++ b/contracts/carrot-app/src/handlers/swap_helpers.rs
@@ -89,7 +89,7 @@ pub(crate) fn tokens_to_swap(
     let x0_a1 = x0.amount * asset1.amount;
     let x1_a0 = x1.amount * asset0.amount;
 
-    let (offer_asset, ask_asset, mut resulting_balance) = if x0_a1 < x1_a0 {
+    let (offer_asset, ask_asset, resulting_balance) = if x0_a1 < x1_a0 {
         let numerator = x1_a0 - x0_a1;
         let denominator = asset0.amount + price * asset1.amount;
         let y1 = numerator / denominator;
@@ -130,7 +130,6 @@ pub(crate) fn tokens_to_swap(
         )
     };
 
-    resulting_balance.sort_by(|a, b| a.denom.cmp(&b.denom));
     // TODO, compute the resulting balance to be able to deposit back into the pool
     Ok((offer_asset, ask_asset, resulting_balance))
 }

--- a/contracts/carrot-app/src/helpers.rs
+++ b/contracts/carrot-app/src/helpers.rs
@@ -1,7 +1,6 @@
 use abstract_app::{objects::AssetEntry, traits::AbstractNameService};
 use abstract_sdk::Resolve;
-use cosmwasm_std::{Addr, Coin, Deps, Uint128};
-use osmosis_std::cosmwasm_to_proto_coins;
+use cosmwasm_std::{Addr, Deps, Uint128};
 
 use crate::{
     contract::{App, AppResult},
@@ -21,12 +20,4 @@ pub fn get_balance(a: AssetEntry, deps: Deps, address: Addr, app: &App) -> AppRe
     let denom = a.resolve(&deps.querier, &app.ans_host(deps)?)?;
     let user_gas_balance = denom.query_balance(&deps.querier, address.clone())?;
     Ok(user_gas_balance)
-}
-
-/// For passing coins inside osmosis messages they have to be sorted
-pub fn cosmwasm_to_proto_coins_sorted(
-    mut coins: Vec<Coin>,
-) -> Vec<osmosis_std::types::cosmos::base::v1beta1::Coin> {
-    coins.sort_by(|a, b| a.denom.cmp(&b.denom));
-    cosmwasm_to_proto_coins(coins)
 }

--- a/contracts/carrot-app/src/helpers.rs
+++ b/contracts/carrot-app/src/helpers.rs
@@ -1,6 +1,7 @@
 use abstract_app::{objects::AssetEntry, traits::AbstractNameService};
 use abstract_sdk::Resolve;
-use cosmwasm_std::{Addr, Deps, Uint128};
+use cosmwasm_std::{Addr, Coin, Deps, Uint128};
+use osmosis_std::cosmwasm_to_proto_coins;
 
 use crate::{
     contract::{App, AppResult},
@@ -20,4 +21,12 @@ pub fn get_balance(a: AssetEntry, deps: Deps, address: Addr, app: &App) -> AppRe
     let denom = a.resolve(&deps.querier, &app.ans_host(deps)?)?;
     let user_gas_balance = denom.query_balance(&deps.querier, address.clone())?;
     Ok(user_gas_balance)
+}
+
+/// For passing coins inside osmosis messages they have to be sorted
+pub fn cosmwasm_to_proto_coins_sorted(
+    mut coins: Vec<Coin>,
+) -> Vec<osmosis_std::types::cosmos::base::v1beta1::Coin> {
+    coins.sort_by(|a, b| a.denom.cmp(&b.denom));
+    cosmwasm_to_proto_coins(coins)
 }

--- a/contracts/carrot-app/tests/deposit_withdraw.rs
+++ b/contracts/carrot-app/tests/deposit_withdraw.rs
@@ -3,7 +3,8 @@ mod common;
 use crate::common::{create_position, setup_test_tube, USDC, USDT};
 use abstract_interface::{Abstract, AbstractAccount};
 use carrot_app::msg::{
-    AppExecuteMsgFns, AppQueryMsgFns, AssetsBalanceResponse, CompoundStatus, PositionResponse,
+    AppExecuteMsgFns, AppQueryMsgFns, AssetsBalanceResponse, CompoundStatus, CreatePositionMessage,
+    PositionResponse,
 };
 use common::DEX_NAME;
 use cosmwasm_std::{coin, coins, Decimal, Uint128};
@@ -22,7 +23,8 @@ fn deposit_lands() -> anyhow::Result<()> {
     let (_, carrot_app) = setup_test_tube(false)?;
 
     let deposit_amount = 5_000;
-    let max_fee = Uint128::new(deposit_amount).mul_floor(Decimal::percent(3));
+    // Either missed position range or fees
+    let max_difference = Uint128::new(deposit_amount).mul_floor(Decimal::percent(3));
     // Create position
     create_position(
         &carrot_app,
@@ -36,7 +38,7 @@ fn deposit_lands() -> anyhow::Result<()> {
         .balances
         .iter()
         .fold(Uint128::zero(), |acc, e| acc + e.amount);
-    assert!(sum.u128() > deposit_amount - max_fee.u128());
+    assert!(sum.u128() > deposit_amount - max_difference.u128());
 
     // Do the deposit
     carrot_app.deposit(
@@ -51,7 +53,7 @@ fn deposit_lands() -> anyhow::Result<()> {
         .balances
         .iter()
         .fold(Uint128::zero(), |acc, e| acc + e.amount);
-    assert!(sum.u128() > (deposit_amount - max_fee.u128()) * 2);
+    assert!(sum.u128() > (deposit_amount - max_difference.u128()) * 2);
 
     // Do the second deposit
     carrot_app.deposit(
@@ -66,7 +68,7 @@ fn deposit_lands() -> anyhow::Result<()> {
         .balances
         .iter()
         .fold(Uint128::zero(), |acc, e| acc + e.amount);
-    assert!(sum.u128() > (deposit_amount - max_fee.u128()) * 3);
+    assert!(sum.u128() > (deposit_amount - max_difference.u128()) * 3);
     Ok(())
 }
 
@@ -214,7 +216,7 @@ fn deposit_slippage() -> anyhow::Result<()> {
     let (_, carrot_app) = setup_test_tube(false)?;
 
     let deposit_amount = 5_000;
-    let max_fee = Uint128::new(deposit_amount).mul_floor(Decimal::percent(3));
+    let max_difference = Uint128::new(deposit_amount).mul_floor(Decimal::percent(3));
     // Create position
     create_position(
         &carrot_app,
@@ -266,7 +268,7 @@ fn deposit_slippage() -> anyhow::Result<()> {
         .balances
         .iter()
         .fold(Uint128::zero(), |acc, e| acc + e.amount);
-    assert!(sum.u128() > (deposit_amount - max_fee.u128()) * 3);
+    assert!(sum.u128() > (deposit_amount - max_difference.u128()) * 3);
     Ok(())
 }
 
@@ -377,5 +379,51 @@ fn manual_partial_withdraw_position_doesnt_autoclaim() -> anyhow::Result<()> {
     let status = carrot_app.compound_status()?;
     assert!(!status.spread_rewards.is_empty());
 
+    Ok(())
+}
+
+#[test]
+fn shifted_position_create_deposit() -> anyhow::Result<()> {
+    let (_, carrot_app) = setup_test_tube(false)?;
+
+    let deposit_amount = 10_000;
+    let max_difference = Uint128::new(deposit_amount).mul_floor(Decimal::percent(3));
+
+    // Create one-way shifted position
+    carrot_app.create_position(CreatePositionMessage {
+        lower_tick: -37000,
+        upper_tick: 1000,
+        funds: coins(deposit_amount, USDT),
+        asset0: coin(205_000, USDT),
+        asset1: coin(753_000, USDC),
+        max_spread: None,
+        belief_price0: None,
+        belief_price1: None,
+    })?;
+
+    let balance = carrot_app.balance()?;
+    let sum = balance
+        .balances
+        .iter()
+        .fold(Uint128::zero(), |acc, e| acc + e.amount);
+    assert!(sum.u128() > (deposit_amount - max_difference.u128()));
+
+    // Deposit asset0
+    carrot_app.deposit(coins(deposit_amount, USDT), None, None, None)?;
+    let balance = carrot_app.balance()?;
+    let sum = balance
+        .balances
+        .iter()
+        .fold(Uint128::zero(), |acc, e| acc + e.amount);
+    assert!(sum.u128() > (deposit_amount - max_difference.u128()) * 2);
+
+    // Deposit asset1
+    carrot_app.deposit(coins(deposit_amount, USDT), None, None, None)?;
+    let balance = carrot_app.balance()?;
+    let sum = balance
+        .balances
+        .iter()
+        .fold(Uint128::zero(), |acc, e| acc + e.amount);
+    assert!(sum.u128() > (deposit_amount - max_difference.u128()) * 3);
     Ok(())
 }


### PR DESCRIPTION
This PR aims to fix deposit amounts that are passed into `MsgAddToPosition`
It was caused by sorting coins inside swap function and then using elements by index
This PR solves it by:
- To add more clarity added a separate type `AssetsForPosition` for assets that are meant to be deposited inside pool with named `asset0` and `asset1` fields
- Moving sorting of coins to `Into<ProtoCoins>` implementation for that type, making it easier to use