### PR TITLE
[BOT] Fix / Ignore outdated carrots

### DIFF
--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "savings-bot"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 publish = false
 

--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -193,9 +193,14 @@ impl Bot {
         log!(Level::Debug, "version requirement: {ver_req}");
         for app_info in saving_modules.modules {
             let version = app_info.module.info.version.to_string();
-            let version_matches = semver::Version::parse(&version)
+            // Completely ignore outdated carrots
+            if !semver::Version::parse(&version)
                 .map(|v| ver_req.matches(&v))
-                .unwrap_or(false);
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
             let code_id = app_info.module.reference.unwrap_app()?;
 
             let contract_addrs = daemon.rt_handle.block_on(utils::fetch_instances(
@@ -233,8 +238,7 @@ impl Bot {
                     .set(balance.u128().try_into().unwrap());
 
                 // Insert instances that are supposed to be autocompounded
-                if version_matches
-                    && !balance.is_zero()
+                if !balance.is_zero()
                     && utils::has_authz_permission(&abstr, contract_addr).unwrap_or(false)
                 {
                     contract_instances_to_autocompound.insert((


### PR DESCRIPTION
We should just ignore outdated carrots instead of logging them